### PR TITLE
Set the mail id as normal text

### DIFF
--- a/contacts.html
+++ b/contacts.html
@@ -9,7 +9,7 @@
 <body>
   <h3>My Contacts</h3>
   <ul>
-    <li>Email : <a href="pandeyvibhas7@gmail.com">pandeyvibhas7@gmail.com</a></li>
+    <li>Email : pandeyvibhas7@gmail.com</li>
     <li>instagram:<a href="https://www.instagram.com/the_vibhas07/">the_vibhas07</a></li>
     <li>linkedin:<a href="https://www.linkedin.com/in/vibhas-pandey-480783226/">this</a></li>
   </ul>


### PR DESCRIPTION
The mail id was shown as a link which was not directing anywhere correctly (404). 
Therefore, I changed the mail to be a normal text.